### PR TITLE
feat: 게시글 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/ssafeople/backend/domain/board/domain/Board.java
+++ b/src/main/java/com/ssafeople/backend/domain/board/domain/Board.java
@@ -1,5 +1,6 @@
 package com.ssafeople.backend.domain.board.domain;
 
+import com.ssafeople.backend.domain.post.domain.Post;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,6 +9,8 @@ import org.hibernate.annotations.Immutable;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "boards")
@@ -32,6 +35,9 @@ public class Board {
     @Column(name = "updated_at")
     @UpdateTimestamp
     private LocalDateTime updatedAt;
+
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL)
+    private final List<Post> posts = new ArrayList<>();
 
     public Board(String boardName, String description) {
         this.boardName = boardName;

--- a/src/main/java/com/ssafeople/backend/domain/comment/domain/Comment.java
+++ b/src/main/java/com/ssafeople/backend/domain/comment/domain/Comment.java
@@ -9,7 +9,7 @@ public class Comment {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "comment_id")
-    private String id;
+    private Long id;
 
     @ManyToOne
     @JoinColumn(name = "post_id")

--- a/src/main/java/com/ssafeople/backend/domain/post/domain/Post.java
+++ b/src/main/java/com/ssafeople/backend/domain/post/domain/Post.java
@@ -5,6 +5,7 @@ import com.ssafeople.backend.domain.comment.domain.Comment;
 import com.ssafeople.backend.domain.post.domain.vo.PostInfoVO;
 import com.ssafeople.backend.domain.user.domain.User;
 import jakarta.persistence.*;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.Immutable;
@@ -17,6 +18,7 @@ import java.util.List;
 @Entity
 @Table(name = "posts")
 @NoArgsConstructor
+@Getter
 public class Post {
 
     @Id

--- a/src/main/java/com/ssafeople/backend/domain/post/domain/Post.java
+++ b/src/main/java/com/ssafeople/backend/domain/post/domain/Post.java
@@ -1,5 +1,6 @@
 package com.ssafeople.backend.domain.post.domain;
 
+import com.ssafeople.backend.domain.board.domain.Board;
 import com.ssafeople.backend.domain.comment.domain.Comment;
 import com.ssafeople.backend.domain.user.domain.User;
 import jakarta.persistence.*;
@@ -26,6 +27,10 @@ public class Post {
     @JoinColumn(name = "user_id")
     private User user;
 
+    @ManyToOne
+    @JoinColumn(name = "board_id")
+    private Board board;
+
     @Column(name = "title")
     private String title;
 
@@ -41,13 +46,14 @@ public class Post {
     @UpdateTimestamp
     private LocalDateTime updatedAt;
 
-    @OneToMany(mappedBy = "posts", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private final List<Comment> comments = new ArrayList<>();
 
-    public Post(String title, String content, User user) {
+    public Post(String title, String content, User user, Board board) {
         this.title = title;
         this.content = content;
         this.user = user;
+        this.board = board;
 
         user.getPosts().add(this);
     }

--- a/src/main/java/com/ssafeople/backend/domain/post/domain/Post.java
+++ b/src/main/java/com/ssafeople/backend/domain/post/domain/Post.java
@@ -2,6 +2,7 @@ package com.ssafeople.backend.domain.post.domain;
 
 import com.ssafeople.backend.domain.board.domain.Board;
 import com.ssafeople.backend.domain.comment.domain.Comment;
+import com.ssafeople.backend.domain.post.domain.vo.PostInfoVO;
 import com.ssafeople.backend.domain.user.domain.User;
 import jakarta.persistence.*;
 import lombok.NoArgsConstructor;
@@ -56,6 +57,20 @@ public class Post {
         this.board = board;
 
         user.getPosts().add(this);
+        board.getPosts().add(this);
+    }
+
+    public PostInfoVO getPostInfo() {
+        return PostInfoVO.builder()
+                .id(id)
+                .userId(user.getId())
+                .boardId(board.getId())
+                .title(title)
+                .content(content)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
+                .comments(comments)
+                .build();
     }
 
 }

--- a/src/main/java/com/ssafeople/backend/domain/post/domain/repository/PostRepository.java
+++ b/src/main/java/com/ssafeople/backend/domain/post/domain/repository/PostRepository.java
@@ -1,5 +1,10 @@
 package com.ssafeople.backend.domain.post.domain.repository;
 
-public interface PostRepository {
+import com.ssafeople.backend.domain.post.domain.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+    List<Post> findByBoardId(Short boardId);
 }

--- a/src/main/java/com/ssafeople/backend/domain/post/domain/vo/PostInfoVO.java
+++ b/src/main/java/com/ssafeople/backend/domain/post/domain/vo/PostInfoVO.java
@@ -1,0 +1,21 @@
+package com.ssafeople.backend.domain.post.domain.vo;
+
+import com.ssafeople.backend.domain.comment.domain.Comment;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class PostInfoVO {
+    private final Long id;
+    private final Short userId;
+    private final Short boardId;
+    private final String title;
+    private final String content;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+    private final List<Comment> comments;
+}

--- a/src/main/java/com/ssafeople/backend/domain/post/presentation/PostController.java
+++ b/src/main/java/com/ssafeople/backend/domain/post/presentation/PostController.java
@@ -1,5 +1,34 @@
 package com.ssafeople.backend.domain.post.presentation;
 
+import com.ssafeople.backend.domain.post.domain.Post;
+import com.ssafeople.backend.domain.post.service.PostService;
+import com.ssafeople.backend.global.exception.post.PostListEmptyException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/posts")
 public class PostController {
+    private final PostService postService;
+
+    @GetMapping("/post-list")
+    public ResponseEntity<List<Post>> getPostsByBoard(@RequestParam(required = true) Short boardId) {
+        List<Post> posts = null;
+        try {
+            posts = postService.getPostsByBoardId(boardId);
+        } catch (PostListEmptyException e) {
+            log.error("이 게시판은 글이 없네");
+        }
+        return ResponseEntity.ok(posts);
+    }
 
 }

--- a/src/main/java/com/ssafeople/backend/domain/post/presentation/PostController.java
+++ b/src/main/java/com/ssafeople/backend/domain/post/presentation/PostController.java
@@ -1,6 +1,6 @@
 package com.ssafeople.backend.domain.post.presentation;
 
-import com.ssafeople.backend.domain.post.domain.vo.PostInfoVO;
+import com.ssafeople.backend.domain.post.presentation.dto.response.PostSummaryResponse;
 import com.ssafeople.backend.domain.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,8 +16,8 @@ public class PostController {
     private final PostService postService;
 
     @GetMapping
-    public ResponseEntity<List<PostInfoVO>> getPostsByBoard(@PathVariable(name="boardId") Short boardId) {
-        List<PostInfoVO> posts = postService.getPostsByBoardId(boardId);
+    public ResponseEntity<List<PostSummaryResponse>> getPostsByBoard(@PathVariable(name="boardId") Short boardId) {
+        List<PostSummaryResponse> posts = postService.getPostsByBoardId(boardId);
         return ResponseEntity.ok(posts);
     }
 }

--- a/src/main/java/com/ssafeople/backend/domain/post/presentation/PostController.java
+++ b/src/main/java/com/ssafeople/backend/domain/post/presentation/PostController.java
@@ -1,34 +1,23 @@
 package com.ssafeople.backend.domain.post.presentation;
 
-import com.ssafeople.backend.domain.post.domain.Post;
+import com.ssafeople.backend.domain.post.domain.vo.PostInfoVO;
 import com.ssafeople.backend.domain.post.service.PostService;
-import com.ssafeople.backend.global.exception.post.PostListEmptyException;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
+import java.util.*;
 
 @RestController
-@Slf4j
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/posts")
+@RequestMapping("/api/v1/boards/{boardId}/posts")
 public class PostController {
+
     private final PostService postService;
 
-    @GetMapping("/post-list")
-    public ResponseEntity<List<Post>> getPostsByBoard(@RequestParam(required = true) Short boardId) {
-        List<Post> posts = null;
-        try {
-            posts = postService.getPostsByBoardId(boardId);
-        } catch (PostListEmptyException e) {
-            log.error("이 게시판은 글이 없네");
-        }
+    @GetMapping
+    public ResponseEntity<List<PostInfoVO>> getPostsByBoard(@PathVariable(name="boardId") Short boardId) {
+        List<PostInfoVO> posts = postService.getPostsByBoardId(boardId);
         return ResponseEntity.ok(posts);
     }
-
 }

--- a/src/main/java/com/ssafeople/backend/domain/post/presentation/dto/response/PostSummaryResponse.java
+++ b/src/main/java/com/ssafeople/backend/domain/post/presentation/dto/response/PostSummaryResponse.java
@@ -1,0 +1,15 @@
+package com.ssafeople.backend.domain.post.presentation.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PostSummaryResponse {
+    private final Long id;
+    private final String userName;
+    private final String title;
+    private final LocalDateTime createdAt;
+}

--- a/src/main/java/com/ssafeople/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/ssafeople/backend/domain/post/service/PostService.java
@@ -1,9 +1,9 @@
 package com.ssafeople.backend.domain.post.service;
 
-import com.ssafeople.backend.domain.post.domain.vo.PostInfoVO;
+import com.ssafeople.backend.domain.post.presentation.dto.response.PostSummaryResponse;
 
 import java.util.List;
 
 public interface PostService {
-    List<PostInfoVO> getPostsByBoardId(Short boardId);
+    List<PostSummaryResponse> getPostsByBoardId(Short boardId);
 }

--- a/src/main/java/com/ssafeople/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/ssafeople/backend/domain/post/service/PostService.java
@@ -1,9 +1,10 @@
 package com.ssafeople.backend.domain.post.service;
 
 import com.ssafeople.backend.domain.post.domain.Post;
+import com.ssafeople.backend.domain.post.domain.vo.PostInfoVO;
 
 import java.util.List;
 
 public interface PostService {
-    List<Post> getPostsByBoardId(Short boardId);
+    List<PostInfoVO> getPostsByBoardId(Short boardId);
 }

--- a/src/main/java/com/ssafeople/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/ssafeople/backend/domain/post/service/PostService.java
@@ -1,5 +1,9 @@
 package com.ssafeople.backend.domain.post.service;
 
-public interface PostService {
+import com.ssafeople.backend.domain.post.domain.Post;
 
+import java.util.List;
+
+public interface PostService {
+    List<Post> getPostsByBoardId(Short boardId);
 }

--- a/src/main/java/com/ssafeople/backend/domain/post/service/PostService.java
+++ b/src/main/java/com/ssafeople/backend/domain/post/service/PostService.java
@@ -1,6 +1,5 @@
 package com.ssafeople.backend.domain.post.service;
 
-import com.ssafeople.backend.domain.post.domain.Post;
 import com.ssafeople.backend.domain.post.domain.vo.PostInfoVO;
 
 import java.util.List;

--- a/src/main/java/com/ssafeople/backend/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/ssafeople/backend/domain/post/service/PostServiceImpl.java
@@ -2,7 +2,8 @@ package com.ssafeople.backend.domain.post.service;
 
 import com.ssafeople.backend.domain.post.domain.Post;
 import com.ssafeople.backend.domain.post.domain.repository.PostRepository;
-import com.ssafeople.backend.domain.post.domain.vo.PostInfoVO;
+
+import com.ssafeople.backend.domain.post.presentation.dto.response.PostSummaryResponse;
 import com.ssafeople.backend.global.exception.post.PostListEmptyException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,18 +23,24 @@ public class PostServiceImpl implements PostService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<PostInfoVO> getPostsByBoardId(Short boardId) {
+    public List<PostSummaryResponse> getPostsByBoardId(Short boardId) {
         List<Post> posts = postRepository.findByBoardId(boardId);
 
         if (posts.isEmpty()) {
             throw PostListEmptyException.EXCEPTION;
         }
-        List<PostInfoVO> postInfoVOs = new ArrayList<>();
+        List<PostSummaryResponse> responses = new ArrayList<>();
         for (Post post : posts) {
-            PostInfoVO postInfoVO = post.getPostInfo();
-            postInfoVOs.add(postInfoVO);
+            PostSummaryResponse response =
+                    PostSummaryResponse.builder()
+                            .id(post.getId())
+                            .title(post.getTitle())
+                            .userName(post.getUser().getUsername())
+                            .createdAt(post.getCreatedAt())
+                            .build();
+            responses.add(response);
         }
 
-        return postInfoVOs;
+        return responses;
     }
 }

--- a/src/main/java/com/ssafeople/backend/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/ssafeople/backend/domain/post/service/PostServiceImpl.java
@@ -1,5 +1,31 @@
 package com.ssafeople.backend.domain.post.service;
 
-public class PostServiceImpl {
+import com.ssafeople.backend.domain.post.domain.Post;
+import com.ssafeople.backend.domain.post.domain.repository.PostRepository;
+import com.ssafeople.backend.global.exception.post.PostListEmptyException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PostServiceImpl implements PostService {
+
+    private final PostRepository postRepository;
+
+    @Override
+    public List<Post> getPostsByBoardId(Short boardId) {
+        List<Post> posts = postRepository.findByBoardId(boardId);
+
+        if (posts.isEmpty()) {
+            throw PostListEmptyException.EXCEPTION;
+        }
+
+        return posts;
+    }
 }

--- a/src/main/java/com/ssafeople/backend/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/ssafeople/backend/domain/post/service/PostServiceImpl.java
@@ -2,12 +2,14 @@ package com.ssafeople.backend.domain.post.service;
 
 import com.ssafeople.backend.domain.post.domain.Post;
 import com.ssafeople.backend.domain.post.domain.repository.PostRepository;
+import com.ssafeople.backend.domain.post.domain.vo.PostInfoVO;
 import com.ssafeople.backend.global.exception.post.PostListEmptyException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -19,13 +21,19 @@ public class PostServiceImpl implements PostService {
     private final PostRepository postRepository;
 
     @Override
-    public List<Post> getPostsByBoardId(Short boardId) {
+    @Transactional(readOnly = true)
+    public List<PostInfoVO> getPostsByBoardId(Short boardId) {
         List<Post> posts = postRepository.findByBoardId(boardId);
 
         if (posts.isEmpty()) {
             throw PostListEmptyException.EXCEPTION;
         }
+        List<PostInfoVO> postInfoVOs = new ArrayList<>();
+        for (Post post : posts) {
+            PostInfoVO postInfoVO = post.getPostInfo();
+            postInfoVOs.add(postInfoVO);
+        }
 
-        return posts;
+        return postInfoVOs;
     }
 }

--- a/src/main/java/com/ssafeople/backend/global/exception/post/PostListEmptyException.java
+++ b/src/main/java/com/ssafeople/backend/global/exception/post/PostListEmptyException.java
@@ -1,0 +1,12 @@
+package com.ssafeople.backend.global.exception.post;
+
+import com.ssafeople.backend.global.exception.SsafeopleException;
+import com.ssafeople.backend.global.response.failure.ErrorCode;
+
+public class PostListEmptyException extends SsafeopleException {
+    public static final SsafeopleException EXCEPTION = new PostListEmptyException();
+
+    public PostListEmptyException() {
+        super(ErrorCode.EMPTY_POST_LIST);
+    }
+}

--- a/src/main/java/com/ssafeople/backend/global/exception/post/PostListEmptyException.java
+++ b/src/main/java/com/ssafeople/backend/global/exception/post/PostListEmptyException.java
@@ -6,7 +6,7 @@ import com.ssafeople.backend.global.response.failure.ErrorCode;
 public class PostListEmptyException extends SsafeopleException {
     public static final SsafeopleException EXCEPTION = new PostListEmptyException();
 
-    public PostListEmptyException() {
+    private PostListEmptyException() {
         super(ErrorCode.EMPTY_POST_LIST);
     }
 }

--- a/src/main/java/com/ssafeople/backend/global/response/failure/ErrorCode.java
+++ b/src/main/java/com/ssafeople/backend/global/response/failure/ErrorCode.java
@@ -24,7 +24,10 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(500, "내부 서버 에러"),
 
     INVALID_BOARD_ID(404, "유효하지 않은 게시판 접근"),
-    EMPTY_BOARD_LIST(400, "게시판 목록이 존재하지 않음");
+    EMPTY_BOARD_LIST(400, "게시판 목록이 존재하지 않음"),
+
+    INVALID_POST_ID(404, "현재 접근하려는 게시판이 존재하지 않습니다."),
+    EMPTY_POST_LIST(400, "게시글 목록이 존재하지 않음");
 
     private final int status;
     private final String reason;

--- a/src/test/java/com/ssafeople/backend/domain/board/service/BoardServiceImplTest.java
+++ b/src/test/java/com/ssafeople/backend/domain/board/service/BoardServiceImplTest.java
@@ -2,6 +2,7 @@ package com.ssafeople.backend.domain.board.service;
 
 import com.ssafeople.backend.domain.board.domain.Board;
 import com.ssafeople.backend.domain.board.domain.repository.BoardRepository;
+import com.ssafeople.backend.global.exception.board.BoardListEmptyException;
 import com.ssafeople.backend.global.exception.board.BoardNotInRepositoryException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -45,7 +46,7 @@ class BoardServiceImplTest {
     @DisplayName("게시판 목록 조회가 실패하면 예외가 발생한다.")
     void getAllBoards_fail() {
         boardRepository.deleteAll();
-        assertThat(boardService.getAllBoards().size()).isEqualTo(0);
+        assertThrows(BoardListEmptyException.class, () -> boardService.getAllBoards());
     }
 
     @Test

--- a/src/test/java/com/ssafeople/backend/domain/post/service/PostServiceImplTest.java
+++ b/src/test/java/com/ssafeople/backend/domain/post/service/PostServiceImplTest.java
@@ -4,8 +4,10 @@ import com.ssafeople.backend.domain.board.domain.Board;
 import com.ssafeople.backend.domain.board.domain.repository.BoardRepository;
 import com.ssafeople.backend.domain.post.domain.Post;
 import com.ssafeople.backend.domain.post.domain.repository.PostRepository;
+import com.ssafeople.backend.domain.post.domain.vo.PostInfoVO;
 import com.ssafeople.backend.domain.user.domain.User;
 import com.ssafeople.backend.domain.user.domain.repository.UserRepository;
+import com.ssafeople.backend.global.exception.post.PostListEmptyException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -44,24 +47,30 @@ public class PostServiceImplTest {
         userRepository.save(testUser);
         Post post = new Post("테스트 게시물 제목", "테스트 게시물 내용", testUser, testBoard);
         postRepository.save(post);
+        PostInfoVO postInfoVO = post.getPostInfo();
+
         //When
-        List<Post> posts = postService.getPostsByBoardId(testBoard.getId());
+        List<PostInfoVO> posts = postService.getPostsByBoardId(testBoard.getId());
+
         //Then
         assertThat(posts.size()).isEqualTo(1);
-        assertThat(posts.get(0)).isEqualTo(post);
+        assertThat(posts.get(0).getId()).isEqualTo(postInfoVO.getId());
 
     }
 
     @Test
-    @DisplayName("게시글 목록 반환 실패")
+    @DisplayName("게시글 목록을 반환하는데 실패하면 예외를 발생시킨다.")
     void getPostsByBoardId_fail() {
         //Given
-
-        //When
-
-        //Then
-
+        Board testBoard = new Board("TEST", "TEST BOARD");
+        Board testBoard1 = new Board("TEST1", "TEST BOARD 1");
+        boardRepository.save(testBoard);
+        boardRepository.save(testBoard1);
+        User testUser = new User("testUserName", "test123@test.test", "", "TestUserNickName");
+        userRepository.save(testUser);
+        Post post = new Post("테스트 게시물 제목", "테스트 게시물 내용", testUser,testBoard1);
+        postRepository.save(post);
+        //When & Then
+        assertThrows(PostListEmptyException.class, () -> postService.getPostsByBoardId(testBoard.getId()));
     }
-
-
 }

--- a/src/test/java/com/ssafeople/backend/domain/post/service/PostServiceImplTest.java
+++ b/src/test/java/com/ssafeople/backend/domain/post/service/PostServiceImplTest.java
@@ -4,7 +4,7 @@ import com.ssafeople.backend.domain.board.domain.Board;
 import com.ssafeople.backend.domain.board.domain.repository.BoardRepository;
 import com.ssafeople.backend.domain.post.domain.Post;
 import com.ssafeople.backend.domain.post.domain.repository.PostRepository;
-import com.ssafeople.backend.domain.post.domain.vo.PostInfoVO;
+import com.ssafeople.backend.domain.post.presentation.dto.response.PostSummaryResponse;
 import com.ssafeople.backend.domain.user.domain.User;
 import com.ssafeople.backend.domain.user.domain.repository.UserRepository;
 import com.ssafeople.backend.global.exception.post.PostListEmptyException;
@@ -47,14 +47,20 @@ public class PostServiceImplTest {
         userRepository.save(testUser);
         Post post = new Post("테스트 게시물 제목", "테스트 게시물 내용", testUser, testBoard);
         postRepository.save(post);
-        PostInfoVO postInfoVO = post.getPostInfo();
+        PostSummaryResponse response =
+                PostSummaryResponse.builder()
+                        .id(post.getId())
+                        .title(post.getTitle())
+                        .userName(post.getUser().getUsername())
+                        .createdAt(post.getCreatedAt())
+                        .build();
 
         //When
-        List<PostInfoVO> posts = postService.getPostsByBoardId(testBoard.getId());
+        List<PostSummaryResponse> posts = postService.getPostsByBoardId(testBoard.getId());
 
         //Then
         assertThat(posts.size()).isEqualTo(1);
-        assertThat(posts.get(0).getId()).isEqualTo(postInfoVO.getId());
+        assertThat(posts.get(0).getId()).isEqualTo(response.getId());
 
     }
 
@@ -68,7 +74,7 @@ public class PostServiceImplTest {
         boardRepository.save(testBoard1);
         User testUser = new User("testUserName", "test123@test.test", "", "TestUserNickName");
         userRepository.save(testUser);
-        Post post = new Post("테스트 게시물 제목", "테스트 게시물 내용", testUser,testBoard1);
+        Post post = new Post("테스트 게시물 제목", "테스트 게시물 내용", testUser, testBoard1);
         postRepository.save(post);
         //When & Then
         assertThrows(PostListEmptyException.class, () -> postService.getPostsByBoardId(testBoard.getId()));

--- a/src/test/java/com/ssafeople/backend/domain/post/service/PostServiceImplTest.java
+++ b/src/test/java/com/ssafeople/backend/domain/post/service/PostServiceImplTest.java
@@ -1,0 +1,67 @@
+package com.ssafeople.backend.domain.post.service;
+
+import com.ssafeople.backend.domain.board.domain.Board;
+import com.ssafeople.backend.domain.board.domain.repository.BoardRepository;
+import com.ssafeople.backend.domain.post.domain.Post;
+import com.ssafeople.backend.domain.post.domain.repository.PostRepository;
+import com.ssafeople.backend.domain.user.domain.User;
+import com.ssafeople.backend.domain.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+public class PostServiceImplTest {
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private PostService postService;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("게시글 목록 반환 성공")
+    void getPostsByBoardId_success() {
+        //Given
+        Board testBoard = new Board("TEST", "TEST BOARD");
+        boardRepository.save(testBoard);
+        User testUser = new User("testUserName", "test123@test.test", "", "TestUserNickName");
+        userRepository.save(testUser);
+        Post post = new Post("테스트 게시물 제목", "테스트 게시물 내용", testUser, testBoard);
+        postRepository.save(post);
+        //When
+        List<Post> posts = postService.getPostsByBoardId(testBoard.getId());
+        //Then
+        assertThat(posts.size()).isEqualTo(1);
+        assertThat(posts.get(0)).isEqualTo(post);
+
+    }
+
+    @Test
+    @DisplayName("게시글 목록 반환 실패")
+    void getPostsByBoardId_fail() {
+        //Given
+
+        //When
+
+        //Then
+
+    }
+
+
+}


### PR DESCRIPTION
resolved : #43

## 개요 :mag:
- 게시글의 목록 조회 기능을 구현했습니다.
## 작업사항 :memo:
- 게시판 ID에 따른 게시글의 목록 조회 기능 구현
- 게시판 정보 전달 객체 구현
- 게시글 목록 조회 API 구현