### PR TITLE
feat: 댓글 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/ssafeople/backend/domain/comment/domain/repository/CommentRepository.java
+++ b/src/main/java/com/ssafeople/backend/domain/comment/domain/repository/CommentRepository.java
@@ -1,5 +1,10 @@
 package com.ssafeople.backend.domain.comment.domain.repository;
 
-public interface CommentRepository {
+import com.ssafeople.backend.domain.comment.domain.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
 
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    Page<Comment> findByPostId(Long postId, Pageable pageable);
 }

--- a/src/main/java/com/ssafeople/backend/domain/comment/presentation/CommentController.java
+++ b/src/main/java/com/ssafeople/backend/domain/comment/presentation/CommentController.java
@@ -1,5 +1,27 @@
 package com.ssafeople.backend.domain.comment.presentation;
 
+import com.ssafeople.backend.domain.comment.presentation.dto.response.CommentResponse;
+import com.ssafeople.backend.domain.comment.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/boards/{boardId}/posts/{postId}/comments")
 public class CommentController {
 
+    private final CommentService commentService;
+
+    @GetMapping
+    public ResponseEntity<Page<CommentResponse>> getPageCommentsList(
+            @PathVariable Short boardId,
+            @PathVariable Long postId,
+            @RequestParam(required = false, defaultValue = "1", value = "page") int page,
+            @RequestParam(required = false, defaultValue = "10", value = "size") int size
+    ) {
+        Page<CommentResponse> pagedComments = commentService.getCommentListByPostId(boardId, postId, page, size);
+        return ResponseEntity.ok(pagedComments);
+    }
 }

--- a/src/main/java/com/ssafeople/backend/domain/comment/presentation/CommentController.java
+++ b/src/main/java/com/ssafeople/backend/domain/comment/presentation/CommentController.java
@@ -16,12 +16,11 @@ public class CommentController {
 
     @GetMapping
     public ResponseEntity<Page<CommentResponse>> getPageCommentsList(
-            @PathVariable Short boardId,
             @PathVariable Long postId,
             @RequestParam(required = false, defaultValue = "1", value = "page") int page,
             @RequestParam(required = false, defaultValue = "10", value = "size") int size
     ) {
-        Page<CommentResponse> pagedComments = commentService.getCommentListByPostId(boardId, postId, page, size);
+        Page<CommentResponse> pagedComments = commentService.getCommentListByPostId(postId, page, size);
         return ResponseEntity.ok(pagedComments);
     }
 }

--- a/src/main/java/com/ssafeople/backend/domain/comment/presentation/dto/response/CommentResponse.java
+++ b/src/main/java/com/ssafeople/backend/domain/comment/presentation/dto/response/CommentResponse.java
@@ -1,0 +1,17 @@
+package com.ssafeople.backend.domain.comment.presentation.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class CommentResponse {
+    private final Long id;
+    private final String content;
+    private final LocalDateTime createdAt;
+
+    private final Short userId;
+    private final String nickName;
+}

--- a/src/main/java/com/ssafeople/backend/domain/comment/service/CommentService.java
+++ b/src/main/java/com/ssafeople/backend/domain/comment/service/CommentService.java
@@ -4,5 +4,5 @@ import com.ssafeople.backend.domain.comment.presentation.dto.response.CommentRes
 import org.springframework.data.domain.Page;
 
 public interface CommentService {
-    Page<CommentResponse> getCommentListByPostId(Short boardId, Long postId, int page, int size);
+    Page<CommentResponse> getCommentListByPostId(Long postId, int page, int size);
 }

--- a/src/main/java/com/ssafeople/backend/domain/comment/service/CommentService.java
+++ b/src/main/java/com/ssafeople/backend/domain/comment/service/CommentService.java
@@ -1,5 +1,8 @@
 package com.ssafeople.backend.domain.comment.service;
 
-public interface CommentService {
+import com.ssafeople.backend.domain.comment.presentation.dto.response.CommentResponse;
+import org.springframework.data.domain.Page;
 
+public interface CommentService {
+    Page<CommentResponse> getCommentListByPostId(Short boardId, Long postId, int page, int size);
 }

--- a/src/main/java/com/ssafeople/backend/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/ssafeople/backend/domain/comment/service/CommentServiceImpl.java
@@ -1,5 +1,46 @@
 package com.ssafeople.backend.domain.comment.service;
 
-public class CommentServiceImpl {
+import com.ssafeople.backend.domain.comment.domain.Comment;
+import com.ssafeople.backend.domain.comment.domain.repository.CommentRepository;
+import com.ssafeople.backend.domain.comment.presentation.dto.response.CommentResponse;
+import com.ssafeople.backend.global.exception.comment.CommentListEmptyException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CommentServiceImpl implements CommentService {
+
+    private final CommentRepository commentRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<CommentResponse> getCommentListByPostId(Short boardId, Long postId, int page, int size) {
+        Pageable pageable = PageRequest.of(page - 1, size);
+
+        Page<Comment> commentPage = commentRepository.findByPostId(postId, pageable);
+
+        if(commentPage.isEmpty()) {
+            throw CommentListEmptyException.EXCEPTION;
+        }
+
+        List<CommentResponse> comments = commentPage.getContent().stream()
+                .map(comment -> CommentResponse.builder()
+                        .id(comment.getId())
+                        .userId(comment.getUser().getId())
+                        .nickName(comment.getUser().getNickname())
+                        .content(comment.getContent())
+                        .createdAt(comment.getCreatedAt())
+                        .build())
+                .toList();
+
+        return new PageImpl<>(comments, pageable, commentPage.getTotalElements());
+    }
 }

--- a/src/main/java/com/ssafeople/backend/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/ssafeople/backend/domain/comment/service/CommentServiceImpl.java
@@ -22,7 +22,7 @@ public class CommentServiceImpl implements CommentService {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<CommentResponse> getCommentListByPostId(Short boardId, Long postId, int page, int size) {
+    public Page<CommentResponse> getCommentListByPostId(Long postId, int page, int size) {
         Pageable pageable = PageRequest.of(page - 1, size);
 
         Page<Comment> commentPage = commentRepository.findByPostId(postId, pageable);

--- a/src/main/java/com/ssafeople/backend/global/exception/comment/CommentListEmptyException.java
+++ b/src/main/java/com/ssafeople/backend/global/exception/comment/CommentListEmptyException.java
@@ -1,0 +1,12 @@
+package com.ssafeople.backend.global.exception.comment;
+
+import com.ssafeople.backend.global.exception.SsafeopleException;
+import com.ssafeople.backend.global.response.failure.ErrorCode;
+
+public class CommentListEmptyException extends SsafeopleException {
+
+    public static final SsafeopleException EXCEPTION = new CommentListEmptyException();
+    private CommentListEmptyException() {
+        super(ErrorCode.EMPTY_COMMENT_LIST);
+    }
+}

--- a/src/main/java/com/ssafeople/backend/global/response/failure/ErrorCode.java
+++ b/src/main/java/com/ssafeople/backend/global/response/failure/ErrorCode.java
@@ -29,7 +29,8 @@ public enum ErrorCode {
     INVALID_POST_ID(404, "현재 접근하려는 게시글이 존재하지 않습니다."),
     EMPTY_POST_LIST(400, "게시글 목록이 존재하지 않음"),
 
-    OWNER_NOTEQUAL_NOW(403, "해당 게시글에 대한 권한이 없습니다.");
+    OWNER_NOTEQUAL_NOW(403, "해당 게시글에 대한 권한이 없습니다."),
+    EMPTY_COMMENT_LIST(400, "아직 작성된 댓글이 없습니다.");
 
     private final int status;
     private final String reason;

--- a/src/test/java/com/ssafeople/backend/domain/comment/service/CommentServiceImplTest.java
+++ b/src/test/java/com/ssafeople/backend/domain/comment/service/CommentServiceImplTest.java
@@ -1,0 +1,89 @@
+package com.ssafeople.backend.domain.comment.service;
+
+import com.ssafeople.backend.domain.board.domain.Board;
+import com.ssafeople.backend.domain.board.domain.repository.BoardRepository;
+import com.ssafeople.backend.domain.comment.domain.Comment;
+import com.ssafeople.backend.domain.comment.domain.repository.CommentRepository;
+import com.ssafeople.backend.domain.comment.presentation.dto.response.CommentResponse;
+import com.ssafeople.backend.domain.post.domain.Post;
+import com.ssafeople.backend.domain.post.domain.repository.PostRepository;
+import com.ssafeople.backend.domain.user.domain.User;
+import com.ssafeople.backend.domain.user.domain.repository.UserRepository;
+import com.ssafeople.backend.global.exception.comment.CommentListEmptyException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+public class CommentServiceImplTest {
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private CommentService commentService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    Board testBoard, testBoard1;
+    Post testPost, testPost1;
+    User testUser, testUser1;
+
+    @BeforeEach
+    void setUp() {
+        testBoard = new Board("TEST", "TEST BOARD");
+        testBoard1 = new Board("TEST1", "TEST BOARD 1");
+        boardRepository.save(testBoard);
+        boardRepository.save(testBoard1);
+
+        testUser = new User("testUserName", "test123@test.test", "", "TestUserNickName");
+        testUser1 = new User("testUserName1", "test123@test.test1", "", "TestUser1NickName");
+        userRepository.save(testUser);
+        userRepository.save(testUser1);
+
+        testPost = new Post("testPostTitle", "testPostContent", testUser, testBoard);
+        testPost1 = new Post("testPostTitle1", "testPostContent1", testUser1, testBoard1);
+        postRepository.save(testPost);
+        postRepository.save(testPost1);
+    }
+
+    @Test
+    @DisplayName("댓글 목록 반환 성공")
+    @Transactional(readOnly = true)
+    void getCommentListByPostId_success() {
+        //Given
+        Comment comment = new Comment("Test Content", testPost, testUser);
+        commentRepository.save(comment);
+
+        //When
+        Page<CommentResponse> commentList = commentService.getCommentListByPostId(testBoard.getId(), testPost.getId(), 1, 10);
+
+        //Then
+        assertThat(commentList.get().toList().get(0).getContent()).isEqualTo(comment.getContent());
+    }
+
+    @Test
+    @DisplayName("댓글 목록 반환 실패 시 (댓글 목록이 비어있음) 예외 반생")
+    @Transactional(readOnly = true)
+    void getCommentListByPostId_fail() {
+        //When & Then
+        assertThrows(CommentListEmptyException.class, () -> commentService.getCommentListByPostId(testBoard.getId(), testPost.getId(), 999, 10));
+    }
+}

--- a/src/test/java/com/ssafeople/backend/domain/comment/service/CommentServiceImplTest.java
+++ b/src/test/java/com/ssafeople/backend/domain/comment/service/CommentServiceImplTest.java
@@ -73,7 +73,7 @@ public class CommentServiceImplTest {
         commentRepository.save(comment);
 
         //When
-        Page<CommentResponse> commentList = commentService.getCommentListByPostId(testBoard.getId(), testPost.getId(), 1, 10);
+        Page<CommentResponse> commentList = commentService.getCommentListByPostId(testPost.getId(), 1, 10);
 
         //Then
         assertThat(commentList.get().toList().get(0).getContent()).isEqualTo(comment.getContent());
@@ -84,6 +84,6 @@ public class CommentServiceImplTest {
     @Transactional(readOnly = true)
     void getCommentListByPostId_fail() {
         //When & Then
-        assertThrows(CommentListEmptyException.class, () -> commentService.getCommentListByPostId(testBoard.getId(), testPost.getId(), 999, 10));
+        assertThrows(CommentListEmptyException.class, () -> commentService.getCommentListByPostId(testPost.getId(), 999, 10));
     }
 }


### PR DESCRIPTION
resolved : #69

## 개요 :mag:
- 댓글 목록 조회 기능을 구현했습니다.
## 작업사항 :memo:
- 댓글 목록 DTO 구현
- 댓글 목록 조회 기능 구현
- 댓글 목록 예외 구현
- 댓글 목록 조회 API 구현