### PR TITLE
fix: 데이터 반환 기능 수정

### DIFF
--- a/src/main/java/com/ssafeople/backend/domain/chatting/presentation/ChattingController.java
+++ b/src/main/java/com/ssafeople/backend/domain/chatting/presentation/ChattingController.java
@@ -5,7 +5,6 @@ import com.ssafeople.backend.domain.chatting.presentation.dto.response.ChattingR
 import com.ssafeople.backend.domain.chatting.service.ChattingService;
 import com.ssafeople.backend.domain.user.domain.User;
 import com.ssafeople.backend.global.utils.user.UserUtils;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
@@ -37,9 +36,9 @@ public class ChattingController {
             user = userUtils.getCurrentUser();
         }
 
-        List<ChattingResponse> responses = chattingService.sendMessage(
+        ChattingResponse response = chattingService.sendMessage(
             roomId, chatMessageDto.getContent(), user, simpSessionId);
 
-        template.convertAndSend("/sub/chat/room/" + roomId, responses);
+        template.convertAndSend("/sub/chat/room/" + roomId, response);
     }
 }

--- a/src/main/java/com/ssafeople/backend/domain/chatting/service/ChattingService.java
+++ b/src/main/java/com/ssafeople/backend/domain/chatting/service/ChattingService.java
@@ -5,7 +5,7 @@ import com.ssafeople.backend.domain.user.domain.User;
 import java.util.List;
 
 public interface ChattingService {
-    List<ChattingResponse> sendMessage(Short roomId, String content, User user, String userId);
+    ChattingResponse sendMessage(Short roomId, String content, User user, String userId);
 
     List<ChattingResponse> getChattingRoomsMessages(Short roomId, User user);
 }

--- a/src/main/java/com/ssafeople/backend/domain/chatting/service/ChattingServiceImpl.java
+++ b/src/main/java/com/ssafeople/backend/domain/chatting/service/ChattingServiceImpl.java
@@ -24,7 +24,7 @@ public class ChattingServiceImpl implements ChattingService {
     private final ChattingRoomRepository chattingRoomRepository;
 
     @Override
-    public List<ChattingResponse> sendMessage(Short roomId, String content, User user, String sessionId) {
+    public ChattingResponse sendMessage(Short roomId, String content, User user, String sessionId) {
         ChattingRoom chattingRoom = chattingRoomRepository.findById(roomId)
             .orElseThrow(() -> NotExistChattingRoomException.EXCEPTION);
 
@@ -50,7 +50,12 @@ public class ChattingServiceImpl implements ChattingService {
         chattingMessageRepository.save(chattingMessage);
         chattingRoom.addMessage(chattingMessage);
 
-        return getChattingResponses(chattingRoom);
+        return ChattingResponse.builder()
+            .sessionId(chattingMessage.getSessionId())
+            .nickname(chattingMessage.getNickname())
+            .content(chattingMessage.getContent())
+            .createdAt(chattingMessage.getCreatedAt())
+            .build();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/ssafeople/backend/domain/comment/presentation/CommentController.java
+++ b/src/main/java/com/ssafeople/backend/domain/comment/presentation/CommentController.java
@@ -21,15 +21,15 @@ public class CommentController {
     private final UserUtils userUtils;
 
     @GetMapping
-    public ResponseEntity<Page<CommentResponse>> getPageCommentsList(
+    public Page<CommentResponse> getPageCommentsList(
             @PathVariable Long postId,
             @RequestParam(required = false, defaultValue = "1", value = "page") int page,
             @RequestParam(required = false, defaultValue = "10", value = "size") int size
     ) {
-        Page<CommentResponse> pagedComments = commentService.getCommentListByPostId(postId, page, size);
-        return ResponseEntity.ok(pagedComments);
+        return commentService.getCommentListByPostId(postId, page, size);
     }
 
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
     public ResponseEntity<CommentResponse> writeComment(
             @PathVariable Long postId,
@@ -41,11 +41,10 @@ public class CommentController {
     }
 
     @DeleteMapping("/{commentId}")
-    public ResponseEntity<Void> deleteComment(
+    public void deleteComment(
             @PathVariable Long commentId
     ) {
         User user = userUtils.getCurrentUser();
         commentService.deleteComment(user, commentId);
-        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/ssafeople/backend/domain/post/presentation/PostController.java
+++ b/src/main/java/com/ssafeople/backend/domain/post/presentation/PostController.java
@@ -11,7 +11,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.*;
@@ -25,58 +24,52 @@ public class PostController {
     private final UserUtils userUtils;
 
     @GetMapping
-    public ResponseEntity<Page<PostSummaryResponse>> getPagedPostsByBoardId(
+    public Page<PostSummaryResponse> getPagedPostsByBoardId(
             @PathVariable(name="boardId") Short boardId,
             @RequestParam(required = false, defaultValue = "1", value = "page") int pageNumber,
             @RequestParam(required = false, defaultValue = "15", value = "size") int pageSize
     ) {
-        Page<PostSummaryResponse> pagedPosts = postService.getPagedPostsByBoardId(boardId, pageNumber, pageSize);
-        return ResponseEntity.ok(pagedPosts);
+        return postService.getPagedPostsByBoardId(boardId, pageNumber, pageSize);
     }
 
     @GetMapping("/allPosts")
-    public ResponseEntity<List<PostSummaryResponse>> getAllPostsByBoardId(
+    public List<PostSummaryResponse> getAllPostsByBoardId(
             @PathVariable(name="boardId") Short boardId
     ) {
-        List<PostSummaryResponse> posts = postService.getPostsByBoardId(boardId);
-        return ResponseEntity.ok(posts);
+        return postService.getPostsByBoardId(boardId);
     }
 
     @GetMapping("/{postId}")
-    public ResponseEntity<PostDetailResponse> getPost(
+    public PostDetailResponse getPost(
             @PathVariable(name="postId") Long postId
     ) {
-        PostDetailResponse response = postService.getPostById(postId);
-        return ResponseEntity.ok(response);
+        return postService.getPostById(postId);
     }
 
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
-    public ResponseEntity<Void> writePost(
+    public void writePost(
             @PathVariable(name="boardId") Short boardId,
             @Valid @RequestBody PostWriteRequest request
     ) {
         User user = userUtils.getCurrentUser();
         postService.writePost(request, boardId, user);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @PatchMapping("/{postId}")
-    public ResponseEntity<Void> updatePost(
+    public void updatePost(
         @PathVariable(name = "postId") Long postId,
         @Valid @RequestBody PostUpdateRequest request
     ) {
         User user = userUtils.getCurrentUser();
         postService.updatePost(request, postId, user);
-        return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/{postId}")
-    public ResponseEntity<Void> deletePost(
+    public void deletePost(
             @PathVariable(name = "postId") Long postId
     ) {
         User user = userUtils.getCurrentUser();
         postService.deletePost(postId, user);
-        return ResponseEntity.noContent().build();
     }
-
 }

--- a/src/main/java/com/ssafeople/backend/domain/user/presentation/UserController.java
+++ b/src/main/java/com/ssafeople/backend/domain/user/presentation/UserController.java
@@ -83,27 +83,23 @@ public class UserController {
     }
 
     @GetMapping
-    public ResponseEntity<UserInfoResponse> getUser() {
+    public UserInfoResponse getUser() {
         User user = userUtils.getCurrentUser();
-        UserInfoResponse userInfoResponse = new UserInfoResponse(user.getUserInfo());
-        return ResponseEntity.ok(userInfoResponse);
+        return new UserInfoResponse(user.getUserInfo());
     }
 
     @GetMapping("/{userId}")
-    public ResponseEntity<UserInfoResponse> getUser(@PathVariable Short userId) {
+    public UserInfoResponse getUser(@PathVariable Short userId) {
         User user = userService.getUserById(userId);
-        UserInfoResponse userInfoResponse = new UserInfoResponse(user.getUserInfo());
-        return ResponseEntity.ok(userInfoResponse);
+        return new UserInfoResponse(user.getUserInfo());
     }
 
-
     @PatchMapping
-    public ResponseEntity<UserInfoResponse> updateUserInfo(
+    public UserInfoResponse updateUserInfo(
         @Valid @RequestBody UserUpdateRequest userUpdateRequest) {
         User user = userUtils.getCurrentUser();
         userService.updateProcess(user, userUpdateRequest);
-        UserInfoResponse userInfoResponse = new UserInfoResponse(user.getUserInfo());
-        return ResponseEntity.ok(userInfoResponse);
+        return new UserInfoResponse(user.getUserInfo());
     }
 
     @DeleteMapping
@@ -113,16 +109,14 @@ public class UserController {
     }
 
     @PostMapping("/change-password")
-    public ResponseEntity<UserInfoResponse> changePassword(
+    public UserInfoResponse changePassword(
         @Valid @RequestBody ChangePasswordRequest changePasswordRequest) {
 
         emailService.isEmailVerified(changePasswordRequest.getEmail());
         User user = userService.getUser(changePasswordRequest.getEmail());
         userService.changePassword(user, changePasswordRequest);
         UserInfoVo userinfoVo = user.getUserInfo();
-        UserInfoResponse userInfoResponse = new UserInfoResponse(userinfoVo);
-
-        return ResponseEntity.ok(userInfoResponse);
+        return new UserInfoResponse(userinfoVo);
     }
 
     @PostMapping("/send-verification-code-change-password")
@@ -135,14 +129,12 @@ public class UserController {
     }
 
     @PostMapping("/readme")
-    public ResponseEntity<UserInfoResponse> updateReadme(
+    public UserInfoResponse updateReadme(
         @RequestBody ChangeReadmeRequest changeReadmeRequest) {
         User user = userUtils.getCurrentUser();
         userService.changeReadme(user, changeReadmeRequest.getReadme());
 
         UserInfoVo userInfo = user.getUserInfo();
-        UserInfoResponse userInfoResponse = new UserInfoResponse(userInfo);
-        return ResponseEntity.ok(userInfoResponse);
+        return new UserInfoResponse(userInfo);
     }
-
 }

--- a/src/main/java/com/ssafeople/backend/global/response/success/SuccessResponseAdvice.java
+++ b/src/main/java/com/ssafeople/backend/global/response/success/SuccessResponseAdvice.java
@@ -14,7 +14,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
 @Slf4j
 @NonNullApi
-@RestControllerAdvice(basePackages = "com.ssafeople.backend")
+@RestControllerAdvice
 public class SuccessResponseAdvice implements ResponseBodyAdvice<Object> {
 
     @Override


### PR DESCRIPTION
resolved : #77 

## 개요 :mag:
- 컨트롤러에서 데이터 반환을 간단히 하기 위해 수정했습니다.
## 작업사항 :memo:
- 채팅 컨트롤러에서 데이터 반환 개수 수정
- User 컨트롤러에서 ResponseEntity가 아닌 객체를 반환하도록 수정
- Post 컨트롤러에서 ResponseEntity가 아닌  객체를 반환하도록 수정
- Comment 컨트롤러에서 ResponseEntity가 아닌  객체를 반환하도록 수정