### PR TITLE
fix: 실명 채팅 기능 수정

### DIFF
--- a/src/main/java/com/ssafeople/backend/domain/chatting/presentation/ChatDateController.java
+++ b/src/main/java/com/ssafeople/backend/domain/chatting/presentation/ChatDateController.java
@@ -2,8 +2,6 @@ package com.ssafeople.backend.domain.chatting.presentation;
 
 import com.ssafeople.backend.domain.chatting.presentation.dto.response.ChattingResponse;
 import com.ssafeople.backend.domain.chatting.service.ChattingService;
-import com.ssafeople.backend.domain.user.domain.User;
-import com.ssafeople.backend.global.exception.user.UserNotFoundException;
 import com.ssafeople.backend.global.utils.user.UserUtils;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -24,13 +22,8 @@ public class ChatDateController {
 
     @GetMapping("/{roomId}")
     public List<ChattingResponse> getMessages(@PathVariable("roomId") Short roomId) {
-        User user = null;
-        try {
-            userUtils.getCurrentUser();
-        } catch (UserNotFoundException e) {
-           log.info("로그인 하지 않은 사용자");
-        }
-        return chattingService.getChattingRoomsMessages(roomId, user);
+        userUtils.getCurrentUser();
+        return chattingService.getChattingRoomsMessages(roomId);
     }
 
 }

--- a/src/main/java/com/ssafeople/backend/domain/chatting/service/ChattingService.java
+++ b/src/main/java/com/ssafeople/backend/domain/chatting/service/ChattingService.java
@@ -7,5 +7,5 @@ import java.util.List;
 public interface ChattingService {
     ChattingResponse sendMessage(Short roomId, String content, User user);
 
-    List<ChattingResponse> getChattingRoomsMessages(Short roomId, User user);
+    List<ChattingResponse> getChattingRoomsMessages(Short roomId);
 }

--- a/src/main/java/com/ssafeople/backend/domain/chatting/service/ChattingServiceImpl.java
+++ b/src/main/java/com/ssafeople/backend/domain/chatting/service/ChattingServiceImpl.java
@@ -7,7 +7,6 @@ import com.ssafeople.backend.domain.chatting.domain.room.repository.ChattingRoom
 import com.ssafeople.backend.domain.chatting.presentation.dto.response.ChattingResponse;
 import com.ssafeople.backend.domain.user.domain.User;
 import com.ssafeople.backend.global.exception.chatting.NotExistChattingRoomException;
-import com.ssafeople.backend.global.exception.chatting.UserNotLoggedInException;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -56,13 +55,9 @@ public class ChattingServiceImpl implements ChattingService {
 
     @Transactional(readOnly = true)
     @Override
-    public List<ChattingResponse> getChattingRoomsMessages(Short roomId, User user) {
+    public List<ChattingResponse> getChattingRoomsMessages(Short roomId) {
         ChattingRoom chattingRoom = chattingRoomRepository.findById(roomId)
             .orElseThrow(() -> NotExistChattingRoomException.EXCEPTION);
-
-        if (!chattingRoom.getIsAnonymous() && user == null) {
-            throw UserNotLoggedInException.EXCEPTION;
-        }
         return getChattingResponses(chattingRoom);
     }
 


### PR DESCRIPTION
resolved : #95 

## 개요 :mag:
- 실명 채팅 프론트 테스트 오류로 인한 수정
## 작업사항 :memo:
- 실명 채팅시 서비스 계층에서 사용자 인증을 확인하는 부분을 제거했습니다.